### PR TITLE
[#2] SignUp request 구현 및 전송 로직 설정

### DIFF
--- a/WatNi.xcodeproj/project.pbxproj
+++ b/WatNi.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		7E604FB723C1CF8A00842B72 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 7E604FB623C1CF8A00842B72 /* Kingfisher */; };
 		7E651EC023C393E200C43CFA /* KeychainProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E651EBF23C393E200C43CFA /* KeychainProvider.swift */; };
 		7E651EC223C4EB4200C43CFA /* KeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E651EC123C4EB4200C43CFA /* KeychainTests.swift */; };
+		7E662F5423D74A9F005A68B7 /* MemberTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E662F5323D74A9F005A68B7 /* MemberTarget.swift */; };
 		7E68A70523B49C2D0021371D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E68A70423B49C2D0021371D /* AppDelegate.swift */; };
 		7E68A70723B49C2D0021371D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E68A70623B49C2D0021371D /* SceneDelegate.swift */; };
 		7E68A70E23B49C2F0021371D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E68A70D23B49C2F0021371D /* Assets.xcassets */; };
@@ -80,6 +81,7 @@
 		7E5D4F5523CB2F3F0008D92D /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
 		7E651EBF23C393E200C43CFA /* KeychainProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainProvider.swift; sourceTree = "<group>"; };
 		7E651EC123C4EB4200C43CFA /* KeychainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainTests.swift; sourceTree = "<group>"; };
+		7E662F5323D74A9F005A68B7 /* MemberTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberTarget.swift; sourceTree = "<group>"; };
 		7E68A70123B49C2D0021371D /* WatNi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WatNi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E68A70423B49C2D0021371D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7E68A70623B49C2D0021371D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -311,6 +313,7 @@
 			isa = PBXGroup;
 			children = (
 				7EB3C3BF23C9EAA700A2B41C /* AuthTarget.swift */,
+				7E662F5323D74A9F005A68B7 /* MemberTarget.swift */,
 			);
 			path = APITarget;
 			sourceTree = "<group>";
@@ -488,6 +491,7 @@
 				7EB3C3B923C9E49700A2B41C /* SignInViewController.swift in Sources */,
 				7E68A70723B49C2D0021371D /* SceneDelegate.swift in Sources */,
 				7E9F6A8823D35AE600E78027 /* SubmitButton.swift in Sources */,
+				7E662F5423D74A9F005A68B7 /* MemberTarget.swift in Sources */,
 				7E2776C123CB7C6D00B90F80 /* UIControl+Publisher.swift in Sources */,
 				7E68A73923B4AA0A0021371D /* UIView+Nib.swift in Sources */,
 				7E68A73723B4A9D20021371D /* UIColor+Initializers.swift in Sources */,

--- a/WatNi/Module/APITarget/MemberTarget.swift
+++ b/WatNi/Module/APITarget/MemberTarget.swift
@@ -1,0 +1,99 @@
+//
+//  MemberTarget.swift
+//  WatNi
+//
+//  Created by 홍창남 on 2020/01/22.
+//  Copyright © 2020 hcn1519. All rights reserved.
+//
+
+import Foundation
+import Moya
+
+enum MemberTarget: TargetType {
+
+    /// 회원 가입
+    case signUp(Encodable)
+
+    var baseURL: URL {
+        return APIConfig.baseURL
+    }
+
+    var path: String {
+        switch self {
+        case .signUp:
+            return "sign-up"
+        }
+    }
+
+    var method: Moya.Method {
+        switch self {
+        case .signUp:
+            return .post
+        }
+    }
+
+    var sampleData: Data {
+        return Data()
+    }
+
+    var task: Moya.Task {
+        switch self {
+        case .signUp(let body):
+            return .requestJSONEncodable(body)
+        }
+    }
+
+    var headers: [String: String]? {
+        return ["Content-Type": "application/json"]
+    }
+}
+
+extension URLRequest {
+
+    /// Moya의 TargetType을 통해 URLRequest 생성
+    init(target: TargetType) {
+        let endpointURL = target.baseURL.appendingPathComponent(target.path)
+        self.init(url: endpointURL, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 10.0)
+
+        httpMethod = target.method.rawValue
+        target.headers?.forEach {
+            self.addValue($0.value, forHTTPHeaderField: $0.key)
+        }
+
+        guard target.method == .post else {
+            return
+        }
+
+        switch target.task {
+        case .requestJSONEncodable(let encodable):
+            self.httpBody = encode(encodable: encodable)
+        default:
+            break
+        }
+    }
+
+    private func encode(encodable: Encodable) -> Data? {
+        do {
+            let encodable = AnyEncodable(encodable)
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(encodable)
+            return data
+        } catch {
+            print(error)
+        }
+        return nil
+    }
+
+    struct AnyEncodable: Encodable {
+
+        private let encodable: Encodable
+
+        public init(_ encodable: Encodable) {
+            self.encodable = encodable
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try encodable.encode(to: encoder)
+        }
+    }
+}

--- a/WatNi/UIWidgets/Signup/SignupViewController.swift
+++ b/WatNi/UIWidgets/Signup/SignupViewController.swift
@@ -48,6 +48,7 @@ class SignupViewController: UIViewController, ViewModelInjectable {
         passwordConfirmTextFieldView.textField.delegate = self
 
         subscribeTextField()
+        subscribeSignUpButton()
     }
 
     @IBAction func naviBackBtnTapped(_ sender: UIButton) {
@@ -56,6 +57,28 @@ class SignupViewController: UIViewController, ViewModelInjectable {
 }
 
 extension SignupViewController {
+
+    private func subscribeSignUpButton() {
+        signUpButton.publisher(for: .touchUpInside).sink { [weak self] (sender) in
+            sender.isUserInteractionEnabled = false
+            self?.viewModel.signUp(completionHandler: { (result) in
+                defer {
+                    sender.isUserInteractionEnabled = true
+                }
+                switch result {
+                case .failure(let error):
+                    let alertController = UIAlertController(title: "회원 가입 실패",
+                                                            message: error.localizedDescription,
+                                                            preferredStyle: .alert)
+                    alertController.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
+                    self?.present(alertController, animated: true, completion: nil)
+                case .success:
+                    // TODO: 회원가입 성공 로직 처리
+                    print("success")
+                }
+            })
+        }.store(in: &cancelables)
+    }
 
     private func subscribeTextField() {
         nameTextFieldView.viewModel = viewModel.createUnderlineViewModel(inputType: .name)

--- a/WatNi/UIWidgets/Signup/SignupViewModel.swift
+++ b/WatNi/UIWidgets/Signup/SignupViewModel.swift
@@ -20,7 +20,7 @@ class SignupViewModel: ObservableObject {
     private var password: String = ""
     private var passwordConfirm: String = ""
 
-    private var disposable = Set<AnyCancellable>()
+    private var cancelables = Set<AnyCancellable>()
 
     /// 유효한 이메일 여부
     var isValidEmail: Bool {
@@ -116,5 +116,29 @@ class SignupViewModel: ObservableObject {
         case .passwordConfirm:
             return "비밀번호가 일치하지 않습니다."
         }
+    }
+
+    func signUp(completionHandler: @escaping (Result<Void, Error>) -> Void) {
+
+        let body = [
+            "email": email,
+            "password": password,
+            "name": name
+        ]
+
+        let request = URLRequest(target: MemberTarget.signUp(body))
+
+        URLSession.shared.dataTaskPublisher(for: request).sink(receiveCompletion: { completion in
+            DispatchQueue.main.async {
+                if case .failure(let error) = completion {
+                    print("Retrieving data failed with error \(error)")
+                    completionHandler(.failure(error))
+                }
+            }
+          }, receiveValue: { _, _ in
+            DispatchQueue.main.async {
+                completionHandler(.success(()))
+            }
+            }).store(in: &cancelables)
     }
 }


### PR DESCRIPTION
- MemberTarget 정의
- URLSession과 Moya.TargetType 브릿징 extension 구현
- 버튼 탭시 signup 리퀘스트 전송